### PR TITLE
Provide lower case extensions

### DIFF
--- a/src/virtual-webgl.js
+++ b/src/virtual-webgl.js
@@ -49,6 +49,12 @@
       wrapperFnMakerFn: makeANGLE_instanced_arraysWrapper,
     },
   };
+
+  // provide lower case methods as well
+  extensionInfo.webgl_draw_buffers = extensionInfo.WEBGL_draw_buffers;
+  extensionInfo.oes_vertex_array_object = extensionInfo.OES_vertex_array_object;
+  extensionInfo.angle_instanced_arrays = extensionInfo.ANGLE_instanced_arrays;
+
   const extensionSaveRestoreHelpersArray = [];
   const extensionSaveRestoreHelpers = {};
 

--- a/src/virtual-webgl.js
+++ b/src/virtual-webgl.js
@@ -60,7 +60,6 @@
   const sharedInstanceExtension = sharedWebGLContext.getExtension("ANGLE_instanced_arrays");
   const numAttributes = sharedWebGLContext.getParameter(sharedWebGLContext.MAX_VERTEX_ATTRIBS);
   const numTextureUnits = sharedWebGLContext.getParameter(sharedWebGLContext.MAX_COMBINED_TEXTURE_IMAGE_UNITS);
-  let numDrawBuffers;
   const baseState = makeDefaultState(300, 150);
 
   const vs = `

--- a/src/virtual-webgl2.js
+++ b/src/virtual-webgl2.js
@@ -1062,6 +1062,11 @@
     */
   };
 
+  // provide lower case methods as well
+  extensionInfo.webgl_draw_buffers = extensionInfo.WEBGL_draw_buffers;
+  extensionInfo.oes_vertex_array_object = extensionInfo.OES_vertex_array_object;
+  extensionInfo.angle_instanced_arrays = extensionInfo.ANGLE_instanced_arrays;
+
   const texImage2DArgParersMap = new Map([
     [9, function([target, level, internalFormat, width, height, , format, type]) {
       return {target, level, internalFormat, width, height, format, type};


### PR DESCRIPTION
I was testing this great library with multiple [`plotly.js`](https://www.npmjs.com/package/plotly.js) graphs.
Since [`regl`](https://www.npmjs.com/package/regl) passes lower case extension names, adding these lines can help resolve getting missing methods.