### PR TITLE
fix missing methods of v1.0.5

### DIFF
--- a/src/virtual-webgl.js
+++ b/src/virtual-webgl.js
@@ -38,14 +38,14 @@
   };
   const canvasToVirtualContextMap = new Map();
   const extensionInfo = {
-    WEBGL_draw_buffers: {
+    webgl_draw_buffers: {
       wrapperFnMakerFn: makeWEBGL_draw_buffersWrapper,
       saveRestoreMakerFn: makeWEBGL_drawBuffersSaveRestoreHelper,
     },
-    OES_vertex_array_object: {
+    oes_vertex_array_object: {
       wrapperFnMakerFn: makeOES_vertex_array_objectWrapper,
     },
-    ANGLE_instanced_arrays: {
+    angle_instanced_arrays: {
       wrapperFnMakerFn: makeANGLE_instanced_arraysWrapper,
     },
   };


### PR DESCRIPTION
The lowercase methods are missing in v1.0.5 for webgl v1.
This PR fixes the regression.
Thank you!